### PR TITLE
Add Pebble custom notice and change updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ sequenceDiagram
 
 ## Appendix 2: deferring an event
 
-This is the 'normal' way of using `defer()`: an event `event1` comes in but we are not ready to process it; we `defer()` it; when `event2` comes in, the oeprator framework will first flush the queue and fire `event1`, then fire `event2`. The ordering is preserved: `event1` is consumed before `event2` by the charm.
+This is the 'normal' way of using `defer()`: an event `event1` comes in but we are not ready to process it; we `defer()` it; when `event2` comes in, the operator framework will first flush the queue and fire `event1`, then fire `event2`. The ordering is preserved: `event1` is consumed before `event2` by the charm.
 
 ```mermaid
 sequenceDiagram

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ flowchart TD
         subgraph Kubernetes[Only on Kubernetes]
             pebble_ready["[*]-pebble-ready"]:::kubevent
             pebble_custom_notice["[*]-pebble-custom-notice"]:::kubevent
-            pebble_change_updated["[*]-pebble-change-update"]::kubevent
+            pebble_change_updated["[*]-pebble-change-update"]:::kubevent
         end
     end
     


### PR DESCRIPTION
Add the new Pebble events (custom notice and change updated) to the diagrams.

A few drive-by "juju" -> "Juju" as well :smile:.

TODO:
* [ ] Finish updating the simulator as well.
* [ ] Once the Juju docs have been updated make sure that the change update link is correct (currently it's a guess).